### PR TITLE
Fix floating point expressions failing depending on system locale

### DIFF
--- a/HomeSpun/Exprs.cs
+++ b/HomeSpun/Exprs.cs
@@ -1613,6 +1613,7 @@ namespace Homespun
             JmpTarget saveQuitJmpTarget = SymbolTable.quitJmpTarget;
             JmpTarget nextJmpTarget = SymbolTable.nextJmpTarget = new JmpTarget();
             JmpTarget quitJmpTarget = SymbolTable.quitJmpTarget = new JmpTarget();
+	    bool saveInsidePlainRepeat = SymbolTable.insidePlainRepeat;
             int saveCaseNesting = SymbolTable.caseNesting;
             SymbolTable.caseNesting = 0;
 
@@ -1693,6 +1694,7 @@ namespace Homespun
             SymbolTable.caseNesting = saveCaseNesting;
             SymbolTable.nextJmpTarget = saveNextJmpTarget;
             SymbolTable.quitJmpTarget = saveQuitJmpTarget;
+	    SymbolTable.insidePlainRepeat = saveInsidePlainRepeat;
         }
     }
     class RepeatFromToStmt : Stmt

--- a/HomeSpun/Tdop.cs
+++ b/HomeSpun/Tdop.cs
@@ -2223,7 +2223,7 @@ Options:
         {
             try
             {
-                Console.WriteLine("Homespun Spin Compiler 0.32 - Batang Build");
+                Console.WriteLine("Homespun Spin Compiler 0.32p1 - Batang Build");
 
                 ArrayList filenameList = new ArrayList();
                 if (args.Length == 0)

--- a/HomeSpun/Tdop.cs
+++ b/HomeSpun/Tdop.cs
@@ -407,7 +407,7 @@ Precedence	Example Operator
 using System;
 using System.IO;
 using System.Collections;
-using System.Globalization.CultureInfo;
+using System.Globalization;
 
 
 namespace Homespun
@@ -2226,7 +2226,7 @@ Options:
 	    CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture; // Fix float<->string conversions
             try
             {
-                Console.WriteLine("Homespun Spin Compiler 0.32p1 - Batang Build");
+                Console.WriteLine("Homespun Spin Compiler 0.32p2 - Batang Build");
 
                 ArrayList filenameList = new ArrayList();
                 if (args.Length == 0)

--- a/HomeSpun/Tdop.cs
+++ b/HomeSpun/Tdop.cs
@@ -407,6 +407,8 @@ Precedence	Example Operator
 using System;
 using System.IO;
 using System.Collections;
+using System.Globalization.CultureInfo;
+
 
 namespace Homespun
 {
@@ -2221,6 +2223,7 @@ Options:
         }
         static void Main(string[] args)
         {
+	    CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture; // Fix float<->string conversions
             try
             {
                 Console.WriteLine("Homespun Spin Compiler 0.32 - Batang Build");


### PR DESCRIPTION
What absolute a**hole thought making the default float<->string conversion dependent on OS locale was a good idea?